### PR TITLE
Translate hyphens in CLI args

### DIFF
--- a/heare/config/__init__.py
+++ b/heare/config/__init__.py
@@ -217,6 +217,9 @@ def parse_cli_arguments(args: List[str]) -> \
                     idx += 1
             else:
                 value = parts[1].strip()
+            # translate hyphens to underscores to match
+            # syntax requirements
+            flag = flag.replace('-', '_')
             results.append((flag, value))
         idx += 1
 

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -39,3 +39,15 @@ class TestCLIParsing(TestCase):
             ('ssl', 'TRUE'),
             ('tls', '')
         ], parsed)
+
+    def test_underscore_translation(self):
+        args = [
+            '--cool-flag',
+            '--cooler_flag'
+        ]
+
+        parsed, position = parse_cli_arguments(args)
+        self.assertListEqual([
+            ('cool_flag', 'TRUE'),
+            ('cooler_flag', 'TRUE')
+        ], parsed)

--- a/tests/test_setting.py
+++ b/tests/test_setting.py
@@ -39,6 +39,17 @@ class SettingsDefinitionTests(unittest.TestCase):
         self.assertEqual(1.0, result.bar.get())
         self.assertTrue(result.baz.get())
 
+    def test_cli_underscores_to_hyphens(self):
+        class MySettings(SettingsDefinition):
+            foo_bar = Setting(str)
+
+        args = ['--foo_bar=baz']
+        result = MySettings.load(args)
+        self.assertEqual('baz', result.foo_bar.get())
+        args = ['--foo-bar=baz']
+        result = MySettings.load(args)
+        self.assertEqual('baz', result.foo_bar.get())
+
     def test_bad_parser(self):
         class MySettings(SettingsDefinition):
             foo = Setting(str)


### PR DESCRIPTION
Default behavior will auto-translate to underscores, to make simpler
mapping of snake_case property names.